### PR TITLE
Align springdoc dependency with Spring Boot 3.5.6

### DIFF
--- a/AgendamentoMedico/pom.xml
+++ b/AgendamentoMedico/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0</version>
         </dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Summary
- downgrade `springdoc-openapi-starter-webmvc-ui` to version 2.4.0 so it targets the Spring Framework level shipped with Spring Boot 3.5.6 and avoids the `ControllerAdviceBean` constructor mismatch

## Testing
- not run (Maven wrapper download is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de6517bb14832084bfa8aec7daab90