### PR TITLE
Update springdoc dependency for Spring Boot 3.5.6

### DIFF
--- a/AgendamentoMedico/pom.xml
+++ b/AgendamentoMedico/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.6.0</version>
         </dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Summary
- bump `springdoc-openapi-starter-webmvc-ui` to version 2.6.0, which contains the fixes for the updated `ControllerAdviceBean` constructor shipped with Spring Boot 3.5.6 so Swagger UI can load without errors

## Testing
- not run (Maven distribution download is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de6517bb14832084bfa8aec7daab90