### PR TITLE
Fix springdoc ControllerAdviceBean instantiation on Spring 6.2

### DIFF
--- a/AgendamentoMedico/pom.xml
+++ b/AgendamentoMedico/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.6.0</version>
         </dependency>
 	</dependencies>
 

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/OpenAPIConfig.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/OpenAPIConfig.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class OpenAPIConfig {
     @Bean
     public OpenAPI customOpenAPI() {

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/SpringDocCompatibilityConfiguration.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/SpringDocCompatibilityConfiguration.java
@@ -1,0 +1,29 @@
+package com.example.AgendamentoMedico.config;
+
+import org.springdoc.core.providers.ControllerAdviceBeanFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Overrides Springdoc's default {@link ControllerAdviceBeanFactory} so it can
+ * instantiate {@link ControllerAdviceBean} using the constructor that is
+ * available in the Spring Framework version bundled with Spring Boot 3.5.
+ */
+@Configuration
+class SpringDocCompatibilityConfiguration {
+
+    @Bean
+    @Primary
+    ControllerAdviceBeanFactory controllerAdviceBeanFactory(BeanFactory beanFactory) {
+        return new ControllerAdviceBeanFactory(beanFactory) {
+            @Override
+            public ControllerAdviceBean createControllerAdviceBean(Object bean) {
+                return SpringDocControllerAdviceCompatibility.create(bean, beanFactory);
+            }
+        };
+    }
+}
+

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/SpringDocControllerAdviceCompatibility.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/SpringDocControllerAdviceCompatibility.java
@@ -1,0 +1,62 @@
+package com.example.AgendamentoMedico.config;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Utility class that creates {@link ControllerAdviceBean} instances using the
+ * constructor signature that is available in the running Spring Framework
+ * version. Spring Framework 6.2 removed the single argument constructor and
+ * replaced it with a variant that also requires a {@link BeanFactory}. Older
+ * Springdoc releases still call the legacy constructor, which results in a
+ * {@link NoSuchMethodError}. By resolving the appropriate constructor via
+ * reflection we keep the application compatible with both generations.
+ */
+final class SpringDocControllerAdviceCompatibility {
+
+    private static final Constructor<ControllerAdviceBean> TWO_ARG_CTOR;
+    private static final Constructor<ControllerAdviceBean> SINGLE_ARG_CTOR;
+
+    static {
+        TWO_ARG_CTOR = findConstructor(ControllerAdviceBean.class, Object.class, BeanFactory.class);
+        SINGLE_ARG_CTOR = findConstructor(ControllerAdviceBean.class, Object.class);
+    }
+
+    private SpringDocControllerAdviceCompatibility() {
+    }
+
+    static ControllerAdviceBean create(Object advice, BeanFactory beanFactory) {
+        Constructor<ControllerAdviceBean> constructor =
+                TWO_ARG_CTOR != null ? TWO_ARG_CTOR : SINGLE_ARG_CTOR;
+
+        if (constructor == null) {
+            throw new IllegalStateException("Unsupported ControllerAdviceBean constructor signature");
+        }
+
+        try {
+            if (constructor == TWO_ARG_CTOR) {
+                return constructor.newInstance(advice, beanFactory);
+            }
+            return constructor.newInstance(advice);
+        }
+        catch (InstantiationException | IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException("Failed to instantiate ControllerAdviceBean", ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Constructor<ControllerAdviceBean> findConstructor(Class<?> type, Class<?>... parameterTypes) {
+        try {
+            Constructor<?> constructor = type.getDeclaredConstructor(parameterTypes);
+            constructor.setAccessible(true);
+            return (Constructor<ControllerAdviceBean>) constructor;
+        }
+        catch (NoSuchMethodException ex) {
+            return null;
+        }
+    }
+}
+

--- a/AgendamentoMedico/src/main/java/org/springdoc/core/providers/ControllerAdviceBeanFactory.java
+++ b/AgendamentoMedico/src/main/java/org/springdoc/core/providers/ControllerAdviceBeanFactory.java
@@ -1,0 +1,26 @@
+package org.springdoc.core.providers;
+
+import com.example.AgendamentoMedico.config.SpringDocControllerAdviceCompatibility;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Minimal replacement for the Springdoc {@code ControllerAdviceBeanFactory},
+ * which is missing in older releases bundled with this project. It delegates
+ * the actual instantiation of {@link ControllerAdviceBean} to the
+ * compatibility helper so the application can run against both Spring
+ * Framework constructor signatures.
+ */
+public class ControllerAdviceBeanFactory {
+
+    private final BeanFactory beanFactory;
+
+    public ControllerAdviceBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public ControllerAdviceBean createControllerAdviceBean(Object bean) {
+        return SpringDocControllerAdviceCompatibility.create(bean, this.beanFactory);
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the reflective constructor lookup to avoid the unavailable ReflectionUtils helper
- provide a minimal ControllerAdviceBeanFactory implementation that delegates to the compatibility helper so compilation succeeds with springdoc 2.6.0

## Testing
- `sh mvnw -q -DskipTests package` *(fails: Maven download from Maven Central is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6517bb14832084bfa8aec7daab90