### PR TITLE
Specify OpenAPI version in configuration

### DIFF
--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/OpenAPIConfig.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/config/OpenAPIConfig.java
@@ -11,6 +11,7 @@ public class OpenAPIConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                .openapi("3.0.1")
                 .info(new Info()
                         .title("API - Agendamento Médico")
                         .version("v1")


### PR DESCRIPTION
## Summary
- set the generated OpenAPI document's version explicitly so the specification includes the top-level version field

## Testing
- mvn clean package *(fails: Unable to download dependencies from Maven Central; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68de73db14848320b10399bc1784c37e