### PR TITLE
Add documentation comments to REST endpoints

### DIFF
--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/AgendaController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/AgendaController.java
@@ -33,6 +33,8 @@ public class AgendaController {
     @Operation(summary = "Lista todos os agendamentos",
             description = "Retorna todos os agendamentos cadastrados.")
     @ApiResponse(responseCode = "200", description = "Agendamentos listados com sucesso")
+    // Delegamos a busca e a conversão para o service e para o mapper para manter o controller fino
+    // e garantir que as regras de negócio e de apresentação fiquem concentradas em suas camadas.
     public ResponseEntity<List<AgendamentoResponseDTO>> listar() {
         var list = service.listar().stream().map(mapper::toResponse).toList();
         return ResponseEntity.ok(list);
@@ -42,6 +44,8 @@ public class AgendaController {
     @Operation(summary = "Busca um agendamento por ID")
     @ApiResponse(responseCode = "200", description = "Agendamento encontrado")
     @ApiResponse(responseCode = "404", description = "Agendamento não encontrado")
+    // Buscamos o agendamento pelo service para reutilizar a validação de existência e depois
+    // convertê-lo para DTO, assegurando consistência de saída em toda a aplicação.
     public ResponseEntity<AgendamentoResponseDTO> buscarPorId(@PathVariable Long id) {
         Agenda a = service.buscarPorId(id);
         return ResponseEntity.ok(mapper.toResponse(a));
@@ -52,6 +56,8 @@ public class AgendaController {
             description = "Cria um novo agendamento vinculando paciente, médico e data da consulta.")
     @ApiResponse(responseCode = "201", description = "Consulta agendada com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação nos parâmetros")
+    // Reaproveitamos o serviço para orquestrar a criação do agendamento porque ele valida a
+    // disponibilidade de recursos e garante integridade, convertendo o resultado para DTO no retorno.
     public ResponseEntity<AgendamentoResponseDTO> agendar(@Valid @RequestBody AgendamentoRequestDTO dto) {
         var agendamento = service.agendar(
                 dto.getPacienteId(),
@@ -67,6 +73,8 @@ public class AgendaController {
     @ApiResponse(responseCode = "200", description = "Agendamento remarcado com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação")
     @ApiResponse(responseCode = "404", description = "Agendamento não encontrado")
+    // Utilizamos o service para centralizar as regras de remarcação e convertendo a data recebida
+    // em string para LocalDateTime aqui para manter o contrato da API simples ao consumidor.
     public ResponseEntity<Agenda> remarcar(@PathVariable Long id,
                                            @RequestParam String novaDataHora,
                                            @RequestParam TipoConsulta tipoConsulta) {
@@ -81,6 +89,8 @@ public class AgendaController {
             description = "Marca o agendamento como cancelado sem removê-lo do banco de dados.")
     @ApiResponse(responseCode = "200", description = "Agendamento cancelado com sucesso")
     @ApiResponse(responseCode = "404", description = "Agendamento não encontrado")
+    // Chamamos o método de cancelamento do service para que todo o fluxo de atualização de status
+    // aconteça em um único ponto, retornando o objeto atualizado para feedback imediato ao cliente.
     public ResponseEntity<Agenda> cancelar(@PathVariable Long id) {
         return ResponseEntity.ok(service.cancelar(id));
     }
@@ -90,6 +100,8 @@ public class AgendaController {
             description = "Exclui permanentemente um agendamento.")
     @ApiResponse(responseCode = "204", description = "Agendamento removido com sucesso")
     @ApiResponse(responseCode = "404", description = "Agendamento não encontrado")
+    // Delegamos a exclusão ao service para aproveitar validações centralizadas e retornamos 204
+    // para seguir a convenção REST de remoções sem conteúdo.
     public ResponseEntity<Void> deletar(@PathVariable Long id) {
         service.deletar(id);
         return ResponseEntity.noContent().build();

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/ConvenioController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/ConvenioController.java
@@ -21,6 +21,8 @@ public class ConvenioController {
     @GetMapping
     @Operation(summary = "Lista todos os convênios", description = "Retorna uma lista com todos os convênios cadastrados.")
     @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    // Mantemos a listagem concentrada no service para aplicar regras de negócio e retornamos DTOs
+    // para evitar expor o modelo interno diretamente aos consumidores da API.
     public ResponseEntity<List<ConvenioDTO>> listarTodos() {
         return ResponseEntity.ok(service.listarTodos());
     }
@@ -29,6 +31,8 @@ public class ConvenioController {
     @Operation(summary = "Busca convênio por ID", description = "Retorna os dados de um convênio específico.")
     @ApiResponse(responseCode = "200", description = "Convênio encontrado")
     @ApiResponse(responseCode = "404", description = "Convênio não encontrado")
+    // Utilizamos Optional no service para encapsular a regra de existência e responder 404 quando
+    // o recurso não é encontrado, alinhando o comportamento às práticas REST.
     public ResponseEntity<ConvenioDTO> buscarPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ResponseEntity::ok)
@@ -39,6 +43,8 @@ public class ConvenioController {
     @Operation(summary = "Cadastra um novo convênio")
     @ApiResponse(responseCode = "201", description = "Convênio criado com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação")
+    // Encaminhamos o DTO recebido diretamente ao service para aproveitar as validações de negócio
+    // centralizadas e retornamos o objeto salvo para confirmar os dados persistidos.
     public ResponseEntity<ConvenioDTO> salvar(@RequestBody ConvenioDTO dto) {
         return ResponseEntity.ok(service.salvar(dto));
     }
@@ -48,6 +54,8 @@ public class ConvenioController {
     @ApiResponse(responseCode = "200", description = "Convênio atualizado com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação")
     @ApiResponse(responseCode = "404", description = "Convênio não encontrado")
+    // A atualização delegada ao service garante reutilização de regras de validação e permite que
+    // o controller continue apenas coordenando a requisição e a resposta HTTP.
     public ResponseEntity<ConvenioDTO> atualizar(@PathVariable Long id,
                                                  @RequestBody ConvenioDTO dto) {
         return ResponseEntity.ok(service.atualizar(id, dto));
@@ -57,6 +65,8 @@ public class ConvenioController {
     @Operation(summary = "Remove um convênio", description = "Exclui permanentemente um convênio pelo ID informado.")
     @ApiResponse(responseCode = "204", description = "Convênio removido com sucesso")
     @ApiResponse(responseCode = "404", description = "Convênio não encontrado")
+    // O método apenas dispara a remoção no service, que concentra verificações de integridade, e
+    // retornamos 204 para indicar sucesso sem conteúdo adicional.
     public ResponseEntity<Void> deletar(@PathVariable Long id) {
         service.deletar(id);
         return ResponseEntity.noContent().build();

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/EspecialidadeController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/EspecialidadeController.java
@@ -26,6 +26,8 @@ public class EspecialidadeController {
     @Operation(summary = "Lista todas as especialidades",
             description = "Retorna uma lista com todas as especialidades cadastradas.")
     @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    // Centralizamos a lógica de listagem no service para manter o controller responsável apenas
+    // pelo fluxo HTTP e garantir que regras de negócio possam evoluir sem impactar a API.
     public ResponseEntity<List<EspecialidadeDTO>> listarTodas() {
         return ResponseEntity.ok(service.listarTodas());
     }
@@ -35,6 +37,8 @@ public class EspecialidadeController {
             description = "Retorna os dados de uma especialidade específica pelo ID.")
     @ApiResponse(responseCode = "200", description = "Especialidade encontrada")
     @ApiResponse(responseCode = "404", description = "Especialidade não encontrada")
+    // Usamos o Optional retornado pelo service para controlar a resposta HTTP e retornar 404 quando
+    // a especialidade não existe, evitando que o controller implemente validações duplicadas.
     public ResponseEntity<EspecialidadeDTO> buscarPorId(@PathVariable Long id) {
         return service.buscarPorId(id)
                 .map(ResponseEntity::ok)
@@ -45,6 +49,8 @@ public class EspecialidadeController {
     @Operation(summary = "Cadastra uma nova especialidade")
     @ApiResponse(responseCode = "201", description = "Especialidade criada com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação")
+    // Encaminhamos o DTO diretamente ao service, que concentra validações e persistência, para
+    // manter o controller desacoplado das regras de negócio.
     public ResponseEntity<EspecialidadeDTO> salvar(@RequestBody EspecialidadeDTO dto) {
         return ResponseEntity.ok(service.salvar(dto));
     }
@@ -55,6 +61,8 @@ public class EspecialidadeController {
     @ApiResponse(responseCode = "200", description = "Especialidade atualizada com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação")
     @ApiResponse(responseCode = "404", description = "Especialidade não encontrada")
+    // A atualização delegada ao service permite reutilizar validações e mapear o retorno no formato
+    // esperado sem duplicar lógica no controller.
     public ResponseEntity<EspecialidadeDTO> atualizar(@PathVariable Long id,
                                                       @RequestBody EspecialidadeDTO dto) {
         return ResponseEntity.ok(service.atualizar(id, dto));
@@ -65,6 +73,8 @@ public class EspecialidadeController {
             description = "Exclui permanentemente uma especialidade pelo ID informado.")
     @ApiResponse(responseCode = "204", description = "Especialidade removida com sucesso")
     @ApiResponse(responseCode = "404", description = "Especialidade não encontrada")
+    // A remoção é tratada pelo service para garantir consistência e validação antes de excluir,
+    // enquanto o controller apenas retorna o status HTTP adequado.
     public ResponseEntity<Void> deletar(@PathVariable Long id) {
         service.deletar(id);
         return ResponseEntity.noContent().build();

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/MedicoController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/MedicoController.java
@@ -12,8 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/medicos")
 @Tag(name = "Médicos", description = "Gerenciamento de médicos")
@@ -26,6 +24,8 @@ public class MedicoController {
     @Operation(summary = "Lista todos os médicos",
             description = "Retorna uma lista de todos os médicos cadastrados.")
     @ApiResponse(responseCode = "200", description = "Lista de médicos retornada com sucesso")
+    // Encaminhamos os parâmetros de paginação para o service, que encapsula a consulta paginada,
+    // permitindo que o controller apenas repasse o resultado pronto ao cliente.
     public ResponseEntity<Page<MedicoResponseDTO>> listarTodos(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "4") int size) {
@@ -38,6 +38,8 @@ public class MedicoController {
             description = "Retorna os dados de um médico específico pelo ID informado.")
     @ApiResponse(responseCode = "200", description = "Médico encontrado")
     @ApiResponse(responseCode = "404", description = "Médico não encontrado")
+    // A consulta delegada ao service reaproveita as validações de existência e lança exceções
+    // apropriadas, permitindo que o controller apenas traduza o resultado para HTTP 200.
     public ResponseEntity<MedicoResponseDTO> buscarPorId(@PathVariable Long id) {
         return ResponseEntity.ok(medicoService.buscarPorId(id));
     }
@@ -47,6 +49,8 @@ public class MedicoController {
             description = "Retorna todos os médicos que possuem a especialidade informada.")
     @ApiResponse(responseCode = "200", description = "Lista de médicos retornada com sucesso")
     @ApiResponse(responseCode = "404", description = "Nenhum médico encontrado para a especialidade")
+    // Reutilizamos o método do service que executa o filtro por especialidade e paginação para
+    // manter a lógica de consulta concentrada em uma única camada reutilizável.
     public ResponseEntity<Page<MedicoResponseDTO>> listarPorEspecialidade(
             @PathVariable String especialidade,
             @RequestParam(defaultValue = "0") int page,
@@ -60,6 +64,8 @@ public class MedicoController {
             description = "Cria um novo registro de médico no sistema.")
     @ApiResponse(responseCode = "201", description = "Médico cadastrado com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação nos dados do médico")
+    // A criação de médicos fica a cargo do service para aplicar validações e integrações, enquanto
+    // o controller apenas define o status HTTP adequado para o recurso recém-criado.
     public ResponseEntity<MedicoResponseDTO> criar(@RequestBody MedicoRequestDTO medicoRequestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(medicoService.salvar(medicoRequestDTO));
     }
@@ -70,6 +76,8 @@ public class MedicoController {
     @ApiResponse(responseCode = "200", description = "Médico atualizado com sucesso")
     @ApiResponse(responseCode = "400", description = "Erro de validação nos dados")
     @ApiResponse(responseCode = "404", description = "Médico não encontrado")
+    // A atualização passa pelo service para reutilizar validações e garantir que apenas dados
+    // consistentes sejam persistidos, retornando o DTO atualizado ao cliente.
     public ResponseEntity<MedicoResponseDTO> atualizar(@PathVariable Long id, @RequestBody MedicoRequestDTO medicoRequestDTO) {
         return ResponseEntity.ok(medicoService.atualizar(id, medicoRequestDTO));
     }
@@ -79,6 +87,8 @@ public class MedicoController {
             description = "Remove permanentemente um médico pelo ID informado.")
     @ApiResponse(responseCode = "204", description = "Médico excluído com sucesso")
     @ApiResponse(responseCode = "404", description = "Médico não encontrado")
+    // A exclusão é delegada ao service para garantir regras de negócio e, após sucesso, respondemos
+    // com 204 conforme a convenção REST para remoções sem payload.
     public ResponseEntity<Void> excluir(@PathVariable Long id) {
         medicoService.excluir(id);
         return ResponseEntity.noContent().build();

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/PacienteController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/PacienteController.java
@@ -1,11 +1,11 @@
 package com.example.AgendamentoMedico.controllers;
 
-import com.example.AgendamentoMedico.mappers.PacienteMapper;
 import com.example.AgendamentoMedico.dtos.PacienteRequestDTO;
 import com.example.AgendamentoMedico.dtos.PacienteResponseDTO;
 import com.example.AgendamentoMedico.exceptions.ResourceNotFoundException;
 import com.example.AgendamentoMedico.models.Paciente;
 import com.example.AgendamentoMedico.services.PacienteService;
+import com.example.AgendamentoMedico.mappers.PacienteMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-        import java.util.List;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
@@ -26,6 +26,8 @@ public class PacienteController {
     private final PacienteMapper pacienteMapper;
 
     @GetMapping
+    // Buscamos todos os pacientes via service e usamos o mapper para converter as entidades em DTOs
+    // garantindo que o controller apenas coordene o fluxo HTTP sem conhecer a estrutura interna.
     public ResponseEntity<List<PacienteResponseDTO>> getAllPacientes() {
         List<PacienteResponseDTO> pacientes = pacienteService.findAll()
                 .stream()
@@ -35,6 +37,8 @@ public class PacienteController {
     }
 
     @GetMapping("/{id}")
+    // Reutilizamos o service para localizar o paciente e lançamos exceção padronizada quando não
+    // encontrado, permitindo que o controller devolva a resposta já mapeada pelo mapper.
     public ResponseEntity<PacienteResponseDTO> getPacienteById(@PathVariable Long id) {
         Paciente paciente = pacienteService.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado com ID: " + id));
@@ -42,12 +46,16 @@ public class PacienteController {
     }
 
     @GetMapping("/email/{email}")
+    // Centralizamos a busca por e-mail no service para aproveitar caches/validações e retornamos
+    // o DTO mapeado garantindo consistência no contrato exposto.
     public ResponseEntity<PacienteResponseDTO> getPacienteByEmail(@PathVariable String email) {
         Paciente paciente = pacienteService.findByEmail(email);
         return ResponseEntity.ok(pacienteMapper.toResponse(paciente));
     }
 
     @GetMapping("/search")
+    // Delegamos o filtro de nome ao service, que conhece o repositório, e convertimos o resultado
+    // para DTOs antes de retornar ao cliente.
     public ResponseEntity<List<PacienteResponseDTO>> searchPacientesByNome(@RequestParam String nome) {
         List<PacienteResponseDTO> pacientes = pacienteService.findByNomeContaining(nome)
                 .stream()
@@ -57,6 +65,8 @@ public class PacienteController {
     }
 
     @PostMapping
+    // Transformamos o DTO em entidade via mapper e delegamos a persistência ao service para manter
+    // as validações de negócio centralizadas, retornando 201 com o recurso criado.
     public ResponseEntity<PacienteResponseDTO> createPaciente(@Valid @RequestBody PacienteRequestDTO request) {
         Paciente paciente = pacienteMapper.toEntity(request);
         Paciente savedPaciente = pacienteService.save(paciente);
@@ -65,6 +75,8 @@ public class PacienteController {
     }
 
     @PutMapping("/{id}")
+    // Convertendo o DTO em entidade e setando o ID aqui garantimos que o service saiba qual registro
+    // atualizar, mantendo toda a regra de validação e persistência centralizada nele.
     public ResponseEntity<PacienteResponseDTO> updatePaciente(
             @PathVariable Long id,
             @Valid @RequestBody PacienteRequestDTO request) {
@@ -77,6 +89,8 @@ public class PacienteController {
     }
 
     @PatchMapping("/{id}")
+    // Buscamos o paciente existente para garantir que atualizações parciais só ocorram sobre dados
+    // válidos e aplicamos as alterações via mapper para reaproveitar a lógica de mapeamento.
     public ResponseEntity<PacienteResponseDTO> partialUpdatePaciente(
             @PathVariable Long id,
             @RequestBody PacienteRequestDTO request) {
@@ -91,6 +105,8 @@ public class PacienteController {
     }
 
     @DeleteMapping("/{id}")
+    // Delegamos a exclusão ao service para aplicar verificações necessárias e retornamos 204 para
+    // indicar que a operação foi concluída sem conteúdo adicional.
     public ResponseEntity<Void> deletePaciente(@PathVariable Long id) {
         pacienteService.deleteById(id);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## Summary
- add explanatory comments explaining the design choices for each endpoint across the agenda, convênio, especialidade, médico, and paciente controllers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb9957cdc8320958afb9867896111