### PR TITLE
Permite listar médicos sem paginação para agenda

### DIFF
--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/MedicoController.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/controllers/MedicoController.java
@@ -26,11 +26,17 @@ public class MedicoController {
     @Operation(summary = "Lista todos os médicos",
             description = "Retorna uma lista de todos os médicos cadastrados.")
     @ApiResponse(responseCode = "200", description = "Lista de médicos retornada com sucesso")
-    public ResponseEntity<Page<MedicoResponseDTO>> listarTodos(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "4") int size) {
+    public ResponseEntity<?> listarTodos(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
 
-        return ResponseEntity.ok(medicoService.listarTodos(page, size));
+        if (page == null || size == null) {
+            List<MedicoResponseDTO> medicos = medicoService.listarTodos();
+            return ResponseEntity.ok(medicos);
+        }
+
+        Page<MedicoResponseDTO> medicos = medicoService.listarTodos(page, size);
+        return ResponseEntity.ok(medicos);
     }
 
     @GetMapping("/{id}")

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/services/MedicoService.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/services/MedicoService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MedicoService {
@@ -28,6 +29,13 @@ public class MedicoService {
         Pageable pageable = PageRequest.of(page, size);
         return medicoRepository.findAll(pageable)
                 .map(MedicoMapper::toResponseDTO);
+    }
+
+    public List<MedicoResponseDTO> listarTodos() {
+        return medicoRepository.findAll()
+                .stream()
+                .map(MedicoMapper::toResponseDTO)
+                .collect(Collectors.toList());
     }
 
     public MedicoResponseDTO buscarPorId(Long id) {


### PR DESCRIPTION
## Summary
- permite que o endpoint de listagem de médicos retorne todos os registros quando parâmetros de paginação não são informados
- adiciona método de serviço para montar a lista completa de médicos sem paginação

## Testing
- ./mvnw test *(falha: wget não conseguiu baixar dependência do Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dece8c40e48320a92b7a7b063f9f17