### PR TITLE
Configure SQL initialization profiles

### DIFF
--- a/AgendamentoMedico/src/main/resources/application-dev.properties
+++ b/AgendamentoMedico/src/main/resources/application-dev.properties
@@ -1,0 +1,3 @@
+# Development profile configuration for local database initialization
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/AgendamentoMedico/src/main/resources/application.properties
+++ b/AgendamentoMedico/src/main/resources/application.properties
@@ -15,3 +15,6 @@ spring.jpa.show-sql=true
 # Console H2
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+# SQL initialization
+spring.sql.init.mode=embedded

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ AgendamentoMedico/
 - (Opcional) Docker, se for usar container
 
 ### 🔹 Passos
+
+### 🔹 Perfil de desenvolvimento com carga inicial
+Caso precise carregar os dados iniciais fornecidos pelos scripts SQL, execute a aplicação com o perfil `dev` habilitado. Você pode fazer isso adicionando o parâmetro `--spring.profiles.active=dev` ao comando de execução (por exemplo, `mvn spring-boot:run -Dspring-boot.run.arguments=--spring.profiles.active=dev`).
+
+O perfil padrão mantém `spring.sql.init.mode=embedded`, evitando a execução automática dos scripts em bancos de dados persistentes. Já o perfil `dev` reativa a carga inicial e adia a inicialização do JPA para garantir compatibilidade com o banco em memória H2.
+
 1. Clone o repositório:
    ```bash
    git clone https://github.com/seu-usuario/AgendamentoMedico.git


### PR DESCRIPTION
## Summary
- set the default SQL initialization mode to `embedded` to prevent scripts from running against persistent databases
- add a `dev` profile configuration that keeps SQL initialization enabled and defers JPA startup for H2 usage
- document how to activate the `dev` profile when the initial data load is required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded70732408320a75bb99d057621b5