### PR TITLE
Garantir reset do formulário do médico após erros de salvamento

### DIFF
--- a/AgendamentoMedico/src/main/resources/static/js/medico.js
+++ b/AgendamentoMedico/src/main/resources/static/js/medico.js
@@ -194,7 +194,14 @@ function salvarMedico(event) {
       cancelarEdicao();
       carregarMedicos();
     })
-    .catch(err => alert(err.message));
+    .catch(err => {
+      alert(err.message);
+      if (medicoEmEdicaoId) {
+        cancelarEdicao();
+      } else {
+        resetFormularioMedico();
+      }
+    });
 }
 
 function iniciarEdicao(medico) {
@@ -222,18 +229,27 @@ function selecionarEspecialidades(select, nomesEspecialidades) {
   });
 }
 
+function resetFormularioMedico() {
+  const form = document.getElementById('medicoForm');
+  if (form) {
+    form.reset();
+  }
+
+  const select = document.getElementById('especialidades');
+  if (select) {
+    Array.from(select.options).forEach(option => {
+      option.selected = false;
+    });
+  }
+}
+
 function cancelarEdicao() {
   medicoEmEdicaoId = null;
   document.getElementById('formTitle').textContent = 'Novo Médico';
   document.getElementById('submitButton').textContent = 'Salvar Médico';
   document.getElementById('cancelarEdicao').classList.add('hidden');
 
-  const form = document.getElementById('medicoForm');
-  form.reset();
-  const select = document.getElementById('especialidades');
-  Array.from(select.options).forEach(option => {
-    option.selected = false;
-  });
+  resetFormularioMedico();
 }
 
 function excluirMedico(id) {


### PR DESCRIPTION
## Summary
- adiciona rotina compartilhada para resetar o formulário de médicos
- executa o reset também quando ocorrer erro no salvamento ou atualização

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68d5f921483208ad498c92c8ec776