### PR TITLE
Padroniza reset dos formulários em todas as telas

### DIFF
--- a/AgendamentoMedico/src/main/resources/static/agenda.html
+++ b/AgendamentoMedico/src/main/resources/static/agenda.html
@@ -28,34 +28,36 @@
         <div class="glass-card form-card">
             <h2>Agendar Consulta</h2>
 
-            <div class="form-group">
-                <label for="paciente">Paciente</label>
-                <select id="paciente" required>
-                    <option value="">Selecione um paciente</option>
-                </select>
-            </div>
+            <form id="agendaForm">
+                <div class="form-group">
+                    <label for="paciente">Paciente</label>
+                    <select id="paciente" required>
+                        <option value="">Selecione um paciente</option>
+                    </select>
+                </div>
 
-            <div class="form-group">
-                <label for="medico">Médico</label>
-                <select id="medico" required>
-                    <option value="">Selecione um médico</option>
-                </select>
-            </div>
+                <div class="form-group">
+                    <label for="medico">Médico</label>
+                    <select id="medico" required>
+                        <option value="">Selecione um médico</option>
+                    </select>
+                </div>
 
-            <div class="form-group">
-                <label for="tipoConsulta">Tipo de Consulta</label>
-                <select id="tipoConsulta" required>
-                    <option value="PRESENCIAL">Presencial</option>
-                    <option value="REMOTO">Remoto</option>
-                </select>
-            </div>
+                <div class="form-group">
+                    <label for="tipoConsulta">Tipo de Consulta</label>
+                    <select id="tipoConsulta" required>
+                        <option value="PRESENCIAL" selected>Presencial</option>
+                        <option value="REMOTO">Remoto</option>
+                    </select>
+                </div>
 
-            <div class="form-group">
-                <label for="dataHora">Data e Hora</label>
-                <input type="datetime-local" id="dataHora" required>
-            </div>
+                <div class="form-group">
+                    <label for="dataHora">Data e Hora</label>
+                    <input type="datetime-local" id="dataHora" required>
+                </div>
 
-            <button id="btnAgendar" class="btn-primary">Agendar</button>
+                <button type="submit" id="btnAgendar" class="btn-primary">Agendar</button>
+            </form>
         </div>
     </main>
 

--- a/AgendamentoMedico/src/main/resources/static/convenio.html
+++ b/AgendamentoMedico/src/main/resources/static/convenio.html
@@ -25,29 +25,34 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2>Cadastrar / Editar</h2>
+            <h2 id="formTitle">Novo Convênio</h2>
 
-            <div class="form-group">
-                <label for="idConvenio">ID (somente para editar)</label>
-                <input type="number" id="idConvenio" placeholder="Deixe vazio para novo">
-            </div>
+            <form id="convenioForm">
+                <div class="form-group">
+                    <label for="idConvenio">ID (somente para editar)</label>
+                    <input type="text" id="idConvenio" placeholder="Gerado automaticamente" readonly>
+                </div>
 
-            <div class="form-group">
-                <label for="nomeConvenio">Nome do Convênio</label>
-                <input type="text" id="nomeConvenio" placeholder="Ex.: Saúde Mais">
-            </div>
+                <div class="form-group">
+                    <label for="nomeConvenio">Nome do Convênio</label>
+                    <input type="text" id="nomeConvenio" placeholder="Ex.: Saúde Mais" required>
+                </div>
 
-            <div class="form-group">
-                <label for="coberturaConvenio">Cobertura</label>
-                <input type="text" id="coberturaConvenio" placeholder="Ex.: Nacional / Estadual">
-            </div>
+                <div class="form-group">
+                    <label for="coberturaConvenio">Cobertura</label>
+                    <input type="text" id="coberturaConvenio" placeholder="Ex.: Nacional / Estadual" required>
+                </div>
 
-            <div class="form-group">
-                <label for="telefoneConvenio">Telefone de Contato</label>
-                <input type="text" id="telefoneConvenio" placeholder="Ex.: (11) 99999-9999">
-            </div>
+                <div class="form-group">
+                    <label for="telefoneConvenio">Telefone de Contato</label>
+                    <input type="text" id="telefoneConvenio" placeholder="Ex.: (11) 99999-9999">
+                </div>
 
-            <button class="btn-primary" id="btnSalvar">Salvar</button>
+                <div class="form-actions">
+                    <button type="submit" class="btn-primary" id="btnSalvar">Salvar Convênio</button>
+                    <button type="button" class="btn-secondary hidden" id="btnCancelar">Cancelar</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/AgendamentoMedico/src/main/resources/static/css/convenio.css
+++ b/AgendamentoMedico/src/main/resources/static/css/convenio.css
@@ -142,6 +142,24 @@ input::placeholder {
     background: linear-gradient(45deg, #00f2fe, #4facfe);
 }
 
+.btn-secondary {
+    width: 100%;
+    padding: 0.8rem;
+    background: rgba(255,255,255,0.15);
+    border: none;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.btn-secondary:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+}
+
 .pager {
     margin-top: 1rem;
     display: flex;
@@ -168,4 +186,20 @@ input::placeholder {
     color: #ddd;
     font-size: 0.9rem;
     margin-top: 1rem;
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.form-actions .btn-primary,
+.form-actions .btn-secondary {
+    width: auto;
+    flex: 1;
+}
+
+.hidden {
+    display: none !important;
 }

--- a/AgendamentoMedico/src/main/resources/static/css/especialidade.css
+++ b/AgendamentoMedico/src/main/resources/static/css/especialidade.css
@@ -141,6 +141,24 @@ input::placeholder {
     background: linear-gradient(45deg, #00f2fe, #4facfe);
 }
 
+.btn-secondary {
+    width: 100%;
+    padding: 0.8rem;
+    background: rgba(255,255,255,0.15);
+    border: none;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.btn-secondary:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+}
+
 .pager {
     margin-top: 1rem;
     display: flex;
@@ -167,4 +185,20 @@ input::placeholder {
     color: #ddd;
     font-size: 0.9rem;
     margin-top: 1rem;
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.form-actions .btn-primary,
+.form-actions .btn-secondary {
+    width: auto;
+    flex: 1;
+}
+
+.hidden {
+    display: none !important;
 }

--- a/AgendamentoMedico/src/main/resources/static/css/paciente.css
+++ b/AgendamentoMedico/src/main/resources/static/css/paciente.css
@@ -102,6 +102,24 @@ input::placeholder {
     background: linear-gradient(45deg, #00f2fe, #4facfe);
 }
 
+.btn-secondary {
+    width: 100%;
+    padding: 0.8rem;
+    background: rgba(255,255,255,0.15);
+    border: none;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.btn-secondary:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+}
+
 .list {
     list-style: none;
     margin-top: 1rem;
@@ -154,6 +172,18 @@ input::placeholder {
     background: rgba(255,255,255,0.35);
 }
 
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.form-actions .btn-primary,
+.form-actions .btn-secondary {
+    width: auto;
+    flex: 1;
+}
+
 .pager {
     display: flex;
     justify-content: center;
@@ -179,4 +209,8 @@ input::placeholder {
     text-align: center;
     color: #ddd;
     font-size: 0.9rem;
+}
+
+.hidden {
+    display: none !important;
 }

--- a/AgendamentoMedico/src/main/resources/static/especialidade.html
+++ b/AgendamentoMedico/src/main/resources/static/especialidade.html
@@ -25,19 +25,24 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2>Cadastrar / Editar</h2>
+            <h2 id="formTitle">Nova Especialidade</h2>
 
-            <div class="form-group">
-                <label for="idEspecialidade">ID (somente para editar)</label>
-                <input type="number" id="idEspecialidade" placeholder="Deixe vazio para novo">
-            </div>
+            <form id="especialidadeForm">
+                <div class="form-group">
+                    <label for="idEspecialidade">ID (somente para editar)</label>
+                    <input type="text" id="idEspecialidade" placeholder="Gerado automaticamente" readonly>
+                </div>
 
-            <div class="form-group">
-                <label for="nomeEspecialidade">Nome da Especialidade</label>
-                <input type="text" id="nomeEspecialidade" placeholder="Ex.: Cardiologia">
-            </div>
+                <div class="form-group">
+                    <label for="nomeEspecialidade">Nome da Especialidade</label>
+                    <input type="text" id="nomeEspecialidade" placeholder="Ex.: Cardiologia" required>
+                </div>
 
-            <button class="btn-primary" id="btnSalvar">Salvar</button>
+                <div class="form-actions">
+                    <button type="submit" class="btn-primary" id="btnSalvar">Salvar Especialidade</button>
+                    <button type="button" class="btn-secondary hidden" id="btnCancelar">Cancelar</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/AgendamentoMedico/src/main/resources/static/js/agenda.js
+++ b/AgendamentoMedico/src/main/resources/static/js/agenda.js
@@ -11,7 +11,11 @@ document.addEventListener('DOMContentLoaded', () => {
   carregarMedicos();
   carregarAgendamentos();
 
-  document.getElementById('btnAgendar').addEventListener('click', agendarConsulta);
+  const form = document.getElementById('agendaForm');
+  if (form) {
+    form.addEventListener('submit', agendarConsulta);
+  }
+
   document.getElementById('prevPage').addEventListener('click', () => mudarPagina(-1));
   document.getElementById('nextPage').addEventListener('click', () => mudarPagina(1));
 });
@@ -167,13 +171,17 @@ function agendarConsulta(event) {
     })
     .then(() => {
       alert('Consulta agendada com sucesso!');
-      document.getElementById('paciente').value = '';
-      document.getElementById('medico').value = '';
-      document.getElementById('tipoConsulta').value = 'PRESENCIAL';
-      document.getElementById('dataHora').value = '';
+      resetFormularioAgenda();
       carregarAgendamentos();
     })
     .catch(err => {
       alert(err.message || 'Erro ao agendar consulta.');
     });
+}
+
+function resetFormularioAgenda() {
+  const form = document.getElementById('agendaForm');
+  if (form) {
+    form.reset();
+  }
 }

--- a/AgendamentoMedico/src/main/resources/static/js/convenio.js
+++ b/AgendamentoMedico/src/main/resources/static/js/convenio.js
@@ -2,11 +2,21 @@ const API_URL = '/api/convenios';
 let currentPage = 1;
 const pageSize = 5;
 let convenios = [];
+let convenioEmEdicaoId = null;
 
 document.addEventListener('DOMContentLoaded', () => {
     carregarConvenios();
 
-    document.getElementById('btnSalvar').addEventListener('click', salvarConvenio);
+    const form = document.getElementById('convenioForm');
+    if (form) {
+        form.addEventListener('submit', salvarConvenio);
+    }
+
+    const cancelarBtn = document.getElementById('btnCancelar');
+    if (cancelarBtn) {
+        cancelarBtn.addEventListener('click', cancelarEdicaoConvenio);
+    }
+
     document.getElementById('prevPage').addEventListener('click', () => mudarPagina(-1));
     document.getElementById('nextPage').addEventListener('click', () => mudarPagina(1));
 
@@ -79,8 +89,10 @@ function mudarPagina(delta) {
     renderizarLista();
 }
 
-async function salvarConvenio() {
-    const id = document.getElementById('idConvenio').value;
+async function salvarConvenio(event) {
+    event.preventDefault();
+
+    const id = convenioEmEdicaoId;
     const nome = document.getElementById('nomeConvenio').value.trim();
     const cobertura = document.getElementById('coberturaConvenio').value.trim();
     let telefoneContato = document.getElementById('telefoneConvenio').value.replace(/\D/g, '');
@@ -107,28 +119,32 @@ async function salvarConvenio() {
             });
         }
 
-        limparFormulario();
+        alert(id ? 'Convênio atualizado com sucesso!' : 'Convênio salvo com sucesso!');
+        cancelarEdicaoConvenio();
         await carregarConvenios();
-        alert('Convênio salvo com sucesso!');
 
     } catch (error) {
         console.error(error);
         alert('Erro ao salvar o convênio!');
+        if (convenioEmEdicaoId) {
+            cancelarEdicaoConvenio();
+        } else {
+            resetFormularioConvenio();
+        }
     }
 }
 
 function editar(id, nome, cobertura, telefoneContato) {
+    convenioEmEdicaoId = id;
+
+    document.getElementById('formTitle').textContent = 'Editar Convênio';
+    document.getElementById('btnSalvar').textContent = 'Atualizar Convênio';
+    document.getElementById('btnCancelar').classList.remove('hidden');
+
     document.getElementById('idConvenio').value = id;
     document.getElementById('nomeConvenio').value = nome;
     document.getElementById('coberturaConvenio').value = cobertura;
-    document.getElementById('telefoneConvenio').value = telefoneContato;
-}
-
-function limparFormulario() {
-    document.getElementById('idConvenio').value = '';
-    document.getElementById('nomeConvenio').value = '';
-    document.getElementById('coberturaConvenio').value = '';
-    document.getElementById('telefoneConvenio').value = '';
+    document.getElementById('telefoneConvenio').value = telefoneContato || '';
 }
 
 async function deletarConvenio(id) {
@@ -142,4 +158,22 @@ async function deletarConvenio(id) {
         console.error(error);
         alert('Erro ao excluir o convênio!');
     }
+}
+
+function resetFormularioConvenio() {
+    const form = document.getElementById('convenioForm');
+    if (form) {
+        form.reset();
+    }
+    document.getElementById('idConvenio').value = '';
+}
+
+function cancelarEdicaoConvenio() {
+    convenioEmEdicaoId = null;
+
+    document.getElementById('formTitle').textContent = 'Novo Convênio';
+    document.getElementById('btnSalvar').textContent = 'Salvar Convênio';
+    document.getElementById('btnCancelar').classList.add('hidden');
+
+    resetFormularioConvenio();
 }

--- a/AgendamentoMedico/src/main/resources/static/js/especialidade.js
+++ b/AgendamentoMedico/src/main/resources/static/js/especialidade.js
@@ -2,11 +2,21 @@ const API_URL = '/api/especialidades';
 let currentPage = 1;
 const pageSize = 10;
 let especialidades = [];
+let especialidadeEmEdicaoId = null;
 
 document.addEventListener('DOMContentLoaded', () => {
     carregarEspecialidades();
 
-    document.getElementById('btnSalvar').addEventListener('click', salvarEspecialidade);
+    const form = document.getElementById('especialidadeForm');
+    if (form) {
+        form.addEventListener('submit', salvarEspecialidade);
+    }
+
+    const cancelarBtn = document.getElementById('btnCancelar');
+    if (cancelarBtn) {
+        cancelarBtn.addEventListener('click', cancelarEdicaoEspecialidade);
+    }
+
     document.getElementById('prevPage').addEventListener('click', () => mudarPagina(-1));
     document.getElementById('nextPage').addEventListener('click', () => mudarPagina(1));
 });
@@ -62,8 +72,10 @@ function mudarPagina(delta) {
     renderizarLista();
 }
 
-async function salvarEspecialidade() {
-    const id = document.getElementById('idEspecialidade').value;
+async function salvarEspecialidade(event) {
+    event.preventDefault();
+
+    const id = especialidadeEmEdicaoId;
     const nome = document.getElementById('nomeEspecialidade').value.trim();
 
     if (!nome) {
@@ -88,18 +100,27 @@ async function salvarEspecialidade() {
             });
         }
 
-        document.getElementById('idEspecialidade').value = '';
-        document.getElementById('nomeEspecialidade').value = '';
+        alert(id ? 'Especialidade atualizada com sucesso!' : 'Especialidade salva com sucesso!');
+        cancelarEdicaoEspecialidade();
         await carregarEspecialidades();
-        alert('Salvo com sucesso!');
 
     } catch (error) {
         console.error(error);
         alert('Erro ao salvar a especialidade!');
+        if (especialidadeEmEdicaoId) {
+            cancelarEdicaoEspecialidade();
+        } else {
+            resetFormularioEspecialidade();
+        }
     }
 }
 
 function editar(id, nome) {
+    especialidadeEmEdicaoId = id;
+    document.getElementById('formTitle').textContent = 'Editar Especialidade';
+    document.getElementById('btnSalvar').textContent = 'Atualizar Especialidade';
+    document.getElementById('btnCancelar').classList.remove('hidden');
+
     document.getElementById('idEspecialidade').value = id;
     document.getElementById('nomeEspecialidade').value = nome;
 }
@@ -115,4 +136,22 @@ async function deletarEspecialidade(id) {
         console.error(error);
         alert('Erro ao excluir a especialidade!');
     }
+}
+
+function resetFormularioEspecialidade() {
+    const form = document.getElementById('especialidadeForm');
+    if (form) {
+        form.reset();
+    }
+    document.getElementById('idEspecialidade').value = '';
+}
+
+function cancelarEdicaoEspecialidade() {
+    especialidadeEmEdicaoId = null;
+
+    document.getElementById('formTitle').textContent = 'Nova Especialidade';
+    document.getElementById('btnSalvar').textContent = 'Salvar Especialidade';
+    document.getElementById('btnCancelar').classList.add('hidden');
+
+    resetFormularioEspecialidade();
 }

--- a/AgendamentoMedico/src/main/resources/static/js/paciente.js
+++ b/AgendamentoMedico/src/main/resources/static/js/paciente.js
@@ -4,12 +4,22 @@ const API_CONVENIOS = '/api/convenios';
 let pacientes = [];
 let paginaAtual = 1;
 const itensPorPagina = 10;
+let pacienteEmEdicaoId = null;
 
 document.addEventListener('DOMContentLoaded', () => {
     carregarPacientes();
     carregarConvenios();
 
-    document.getElementById('btnSalvar').addEventListener('click', salvarPaciente);
+    const form = document.getElementById('pacienteForm');
+    if (form) {
+        form.addEventListener('submit', salvarPaciente);
+    }
+
+    const cancelarBtn = document.getElementById('btnCancelar');
+    if (cancelarBtn) {
+        cancelarBtn.addEventListener('click', cancelarEdicaoPaciente);
+    }
+
     document.getElementById('prevPage').addEventListener('click', () => mudarPagina(-1));
     document.getElementById('nextPage').addEventListener('click', () => mudarPagina(1));
 
@@ -83,8 +93,10 @@ function mudarPagina(direcao) {
     }
 }
 
-async function salvarPaciente() {
-    const id = document.getElementById('idPaciente').value;
+async function salvarPaciente(event) {
+    event.preventDefault();
+
+    const id = pacienteEmEdicaoId;
     const nome = document.getElementById('nomePaciente').value.trim();
     const email = document.getElementById('emailPaciente').value.trim();
     const telefone = document.getElementById('telefonePaciente').value.replace(/\D/g, '');
@@ -119,13 +131,18 @@ async function salvarPaciente() {
             });
         }
 
-        alert('Paciente salvo com sucesso!');
-        limparFormulario();
+        alert(id ? 'Paciente atualizado com sucesso!' : 'Paciente salvo com sucesso!');
+        cancelarEdicaoPaciente();
         carregarPacientes();
 
     } catch (error) {
         console.error(error);
         alert('Erro ao salvar paciente!');
+        if (pacienteEmEdicaoId) {
+            cancelarEdicaoPaciente();
+        } else {
+            resetFormularioPaciente();
+        }
     }
 }
 
@@ -133,12 +150,7 @@ function editar(id) {
     const paciente = pacientes.find(p => p.id === id);
     if (!paciente) return;
 
-    document.getElementById('idPaciente').value = paciente.id;
-    document.getElementById('nomePaciente').value = paciente.nome;
-    document.getElementById('emailPaciente').value = paciente.email;
-    document.getElementById('telefonePaciente').value = paciente.telefone;
-    document.getElementById('dataNascimentoPaciente').value = paciente.dataNascimento;
-    document.getElementById('convenioPaciente').value = paciente.convenio ? paciente.convenio.id : '';
+    iniciarEdicaoPaciente(paciente);
 }
 
 async function deletarPaciente(id) {
@@ -154,13 +166,37 @@ async function deletarPaciente(id) {
     }
 }
 
-function limparFormulario() {
+function iniciarEdicaoPaciente(paciente) {
+    pacienteEmEdicaoId = paciente.id;
+
+    document.getElementById('formTitle').textContent = 'Editar Paciente';
+    document.getElementById('btnSalvar').textContent = 'Atualizar Paciente';
+    document.getElementById('btnCancelar').classList.remove('hidden');
+
+    document.getElementById('idPaciente').value = paciente.id;
+    document.getElementById('nomePaciente').value = paciente.nome || '';
+    document.getElementById('emailPaciente').value = paciente.email || '';
+    document.getElementById('telefonePaciente').value = paciente.telefone || '';
+    document.getElementById('dataNascimentoPaciente').value = paciente.dataNascimento || '';
+    document.getElementById('convenioPaciente').value = paciente.convenio ? paciente.convenio.id : '';
+}
+
+function resetFormularioPaciente() {
+    const form = document.getElementById('pacienteForm');
+    if (form) {
+        form.reset();
+    }
     document.getElementById('idPaciente').value = '';
-    document.getElementById('nomePaciente').value = '';
-    document.getElementById('emailPaciente').value = '';
-    document.getElementById('telefonePaciente').value = '';
-    document.getElementById('dataNascimentoPaciente').value = '';
-    document.getElementById('convenioPaciente').value = '';
+}
+
+function cancelarEdicaoPaciente() {
+    pacienteEmEdicaoId = null;
+
+    document.getElementById('formTitle').textContent = 'Novo Paciente';
+    document.getElementById('btnSalvar').textContent = 'Salvar Paciente';
+    document.getElementById('btnCancelar').classList.add('hidden');
+
+    resetFormularioPaciente();
 }
 
 function aplicarMascaraTelefone(event) {

--- a/AgendamentoMedico/src/main/resources/static/paciente.html
+++ b/AgendamentoMedico/src/main/resources/static/paciente.html
@@ -25,41 +25,46 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2>Cadastrar / Editar</h2>
+            <h2 id="formTitle">Novo Paciente</h2>
 
-            <div class="form-group">
-                <label for="idPaciente">ID (somente para editar)</label>
-                <input type="number" id="idPaciente" placeholder="Deixe vazio para novo">
-            </div>
+            <form id="pacienteForm">
+                <div class="form-group">
+                    <label for="idPaciente">ID (somente para editar)</label>
+                    <input type="text" id="idPaciente" placeholder="Gerado automaticamente" readonly>
+                </div>
 
-            <div class="form-group">
-                <label for="nomePaciente">Nome</label>
-                <input type="text" id="nomePaciente" placeholder="Ex.: João da Silva">
-            </div>
+                <div class="form-group">
+                    <label for="nomePaciente">Nome</label>
+                    <input type="text" id="nomePaciente" placeholder="Ex.: João da Silva" required>
+                </div>
 
-            <div class="form-group">
-                <label for="emailPaciente">Email</label>
-                <input type="email" id="emailPaciente" placeholder="Ex.: joao@email.com">
-            </div>
+                <div class="form-group">
+                    <label for="emailPaciente">Email</label>
+                    <input type="email" id="emailPaciente" placeholder="Ex.: joao@email.com" required>
+                </div>
 
-            <div class="form-group">
-                <label for="telefonePaciente">Telefone</label>
-                <input type="text" id="telefonePaciente" placeholder="Ex.: (11) 99999-9999">
-            </div>
+                <div class="form-group">
+                    <label for="telefonePaciente">Telefone</label>
+                    <input type="text" id="telefonePaciente" placeholder="Ex.: (11) 99999-9999">
+                </div>
 
-            <div class="form-group">
-                <label for="dataNascimentoPaciente">Data de Nascimento</label>
-                <input type="date" id="dataNascimentoPaciente">
-            </div>
+                <div class="form-group">
+                    <label for="dataNascimentoPaciente">Data de Nascimento</label>
+                    <input type="date" id="dataNascimentoPaciente" required>
+                </div>
 
-            <div class="form-group">
-                <label for="convenioPaciente">Convênio</label>
-                <select id="convenioPaciente">
-                    <option value="">Selecione um convênio</option>
-                </select>
-            </div>
+                <div class="form-group">
+                    <label for="convenioPaciente">Convênio</label>
+                    <select id="convenioPaciente">
+                        <option value="">Selecione um convênio</option>
+                    </select>
+                </div>
 
-            <button class="btn-primary" id="btnSalvar">Salvar</button>
+                <div class="form-actions">
+                    <button type="submit" class="btn-primary" id="btnSalvar">Salvar Paciente</button>
+                    <button type="button" class="btn-secondary hidden" id="btnCancelar">Cancelar</button>
+                </div>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- padronizei os formulários de paciente, especialidade e convênio com elementos `<form>`, botões de cancelar e novos estilos para permitir reset consistente
- atualizei os scripts dessas telas para controlar o estado de edição e reutilizar `form.reset()` ao salvar, cancelar ou falhar
- converti o agendamento para usar `<form>` e limpar os campos com um reset unificado após cada agendamento

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e69a64afcc8320830e6500fadd5148