### PR TITLE
Fix layout for agenda action buttons

### DIFF
--- a/AgendamentoMedico/src/main/resources/static/css/agenda.css
+++ b/AgendamentoMedico/src/main/resources/static/css/agenda.css
@@ -155,6 +155,11 @@ input[type="datetime-local"] {
     word-break: break-word;
 }
 
+.list li > div:first-child {
+    flex: 1;
+    min-width: 0;
+}
+
 .list li span {
     font-size: 0.95rem;
     max-width: 70%;
@@ -167,6 +172,7 @@ input[type="datetime-local"] {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-shrink: 0;
 }
 
 .list li .status {
@@ -177,7 +183,6 @@ input[type="datetime-local"] {
 }
 
 .btn-action {
-    margin-left: 0.5rem;
     padding: 0.4rem 0.7rem;
     font-size: 0.85rem;
     border: none;
@@ -186,6 +191,10 @@ input[type="datetime-local"] {
     background: rgba(255,255,255,0.2);
     color: #fff;
     transition: background 0.3s ease;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .btn-action:hover {


### PR DESCRIPTION
## Summary
- ensure agenda list items reserve space for text and prevent the action buttons from collapsing
- make the action buttons nowrap, flex-aligned, and keep the actions container from shrinking to maintain layout

## Testing
- ./mvnw spring-boot:run *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d3b317b88320abb062f718f6315a