### PR TITLE
Add validation for appointment date and patient scheduling conflicts

### DIFF
--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/repositories/AgendaRepository.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/repositories/AgendaRepository.java
@@ -1,5 +1,6 @@
 package com.example.AgendamentoMedico.repositories;
 
+import com.example.AgendamentoMedico.enums.StatusAgenda;
 import com.example.AgendamentoMedico.models.Agenda;
 import com.example.AgendamentoMedico.models.Medico;
 import com.example.AgendamentoMedico.models.Paciente;
@@ -9,5 +10,5 @@ import java.time.LocalDateTime;
 
 public interface AgendaRepository extends JpaRepository<Agenda, Long> {
     boolean existsByMedicoAndDataHora(Medico medico, LocalDateTime dataHora);
-    boolean existsByPacienteAndDataHora(Paciente paciente, LocalDateTime dataHora);
+    boolean existsByPacienteAndDataHoraAndStatus(Paciente paciente, LocalDateTime dataHora, StatusAgenda status);
 }

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/repositories/AgendaRepository.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/repositories/AgendaRepository.java
@@ -2,10 +2,12 @@ package com.example.AgendamentoMedico.repositories;
 
 import com.example.AgendamentoMedico.models.Agenda;
 import com.example.AgendamentoMedico.models.Medico;
+import com.example.AgendamentoMedico.models.Paciente;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
 public interface AgendaRepository extends JpaRepository<Agenda, Long> {
     boolean existsByMedicoAndDataHora(Medico medico, LocalDateTime dataHora);
+    boolean existsByPacienteAndDataHora(Paciente paciente, LocalDateTime dataHora);
 }

--- a/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/services/AgendaService.java
+++ b/AgendamentoMedico/src/main/java/com/example/AgendamentoMedico/services/AgendaService.java
@@ -68,7 +68,8 @@ public class AgendaService {
             throw new IllegalArgumentException("O médico já possui um agendamento neste horário.");
         }
 
-        boolean pacienteJaAgendado = agendaRepository.existsByPacienteAndDataHora(paciente, dataHora);
+        boolean pacienteJaAgendado = agendaRepository
+                .existsByPacienteAndDataHoraAndStatus(paciente, dataHora, StatusAgenda.AGENDADA);
         if (pacienteJaAgendado) {
             throw new IllegalArgumentException("O paciente já possui um agendamento neste horário.");
         }
@@ -99,7 +100,8 @@ public class AgendaService {
             throw new IllegalArgumentException("O médico já possui um agendamento neste horário.");
         }
 
-        boolean pacienteJaAgendado = agendaRepository.existsByPacienteAndDataHora(agenda.getPaciente(), novaDataHora);
+        boolean pacienteJaAgendado = agendaRepository
+                .existsByPacienteAndDataHoraAndStatus(agenda.getPaciente(), novaDataHora, StatusAgenda.AGENDADA);
         if (pacienteJaAgendado && !agenda.getDataHora().equals(novaDataHora)) {
             throw new IllegalArgumentException("O paciente já possui um agendamento neste horário.");
         }


### PR DESCRIPTION
## Summary
- validate that new appointments cannot be scheduled in the past
- prevent patients from being booked multiple times at the same date and time
- apply the same checks when rescheduling existing appointments

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e73adbb7bc8320b20163affa663e86