### PR TITLE
Add tooltip anchor describing scheduling endpoint

### DIFF
--- a/AgendamentoMedico/src/main/resources/static/agenda.html
+++ b/AgendamentoMedico/src/main/resources/static/agenda.html
@@ -26,7 +26,16 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2>Agendar Consulta</h2>
+            <div class="card-title">
+                <h2>Agendar Consulta</h2>
+                <button type="button" class="endpoint-tooltip" aria-label="Informações sobre o endpoint utilizado neste formulário">
+                    ?
+                    <span class="tooltip-text" role="tooltip">
+                        <strong>Endpoint:</strong> POST /agendas/agendar<br>
+                        Envia os dados do formulário para criar um novo agendamento de consulta.
+                    </span>
+                </button>
+            </div>
 
             <form id="agendaForm">
                 <input type="hidden" id="agendamentoId">

--- a/AgendamentoMedico/src/main/resources/static/css/agenda.css
+++ b/AgendamentoMedico/src/main/resources/static/css/agenda.css
@@ -47,10 +47,81 @@ body {
     flex: 1;
 }
 
+.form-card {
+    position: relative;
+}
+
 .glass-card h2 {
     text-align: center;
     margin-bottom: 1.2rem;
     font-weight: 600;
+}
+
+.card-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+    position: relative;
+}
+
+.card-title h2 {
+    margin-bottom: 0;
+}
+
+.endpoint-tooltip {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.6rem;
+    width: 1.9rem;
+    height: 1.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.6);
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-weight: 700;
+    cursor: help;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.endpoint-tooltip:focus,
+.endpoint-tooltip:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+    outline: none;
+}
+
+.endpoint-tooltip .tooltip-text {
+    position: absolute;
+    top: 130%;
+    right: 0;
+    width: 240px;
+    padding: 0.8rem;
+    border-radius: 12px;
+    background: rgba(19, 43, 64, 0.92);
+    border: 1px solid rgba(255,255,255,0.25);
+    color: #e6f7ff;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    text-align: left;
+    box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.endpoint-tooltip:focus .tooltip-text,
+.endpoint-tooltip:hover .tooltip-text {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
 }
 
 .form-group {


### PR DESCRIPTION
## Summary
- add a contextual tooltip anchor to the "Agendar Consulta" card header with endpoint details
- style the tooltip trigger and popover to match the glassmorphism interface

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e7c50e0b7c8320b26cb9d3ea985f72