### PR TITLE
Add endpoint tooltips to management pages

### DIFF
--- a/AgendamentoMedico/src/main/resources/static/convenio.html
+++ b/AgendamentoMedico/src/main/resources/static/convenio.html
@@ -25,7 +25,16 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2 id="formTitle">Novo Convênio</h2>
+            <div class="card-title">
+                <h2 id="formTitle">Novo Convênio</h2>
+                <button type="button" class="endpoint-tooltip" aria-label="Informações sobre o endpoint utilizado neste formulário">
+                    ?
+                    <span class="tooltip-text" role="tooltip">
+                        <strong>Endpoint:</strong> POST /api/convenios<br>
+                        Usa os dados preenchidos para criar ou alterar um convênio disponível.
+                    </span>
+                </button>
+            </div>
 
             <form id="convenioForm">
                 <div class="form-group">

--- a/AgendamentoMedico/src/main/resources/static/css/convenio.css
+++ b/AgendamentoMedico/src/main/resources/static/css/convenio.css
@@ -61,6 +61,73 @@ body {
     margin-bottom: 1rem;
 }
 
+.card-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+    position: relative;
+}
+
+.card-title h2 {
+    margin: 0;
+}
+
+.endpoint-tooltip {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.6rem;
+    width: 1.9rem;
+    height: 1.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.6);
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-weight: 700;
+    cursor: help;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.endpoint-tooltip:focus,
+.endpoint-tooltip:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+    outline: none;
+}
+
+.endpoint-tooltip .tooltip-text {
+    position: absolute;
+    top: 130%;
+    right: 0;
+    width: 240px;
+    padding: 0.8rem;
+    border-radius: 12px;
+    background: rgba(19, 43, 64, 0.92);
+    border: 1px solid rgba(255,255,255,0.25);
+    color: #e6f7ff;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    text-align: left;
+    box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.endpoint-tooltip:focus .tooltip-text,
+.endpoint-tooltip:hover .tooltip-text {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
 .list {
     list-style: none;
     margin-top: 1rem;

--- a/AgendamentoMedico/src/main/resources/static/css/especialidade.css
+++ b/AgendamentoMedico/src/main/resources/static/css/especialidade.css
@@ -61,6 +61,73 @@ body {
     margin-bottom: 1rem;
 }
 
+.card-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+    position: relative;
+}
+
+.card-title h2 {
+    margin: 0;
+}
+
+.endpoint-tooltip {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.6rem;
+    width: 1.9rem;
+    height: 1.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.6);
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-weight: 700;
+    cursor: help;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.endpoint-tooltip:focus,
+.endpoint-tooltip:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+    outline: none;
+}
+
+.endpoint-tooltip .tooltip-text {
+    position: absolute;
+    top: 130%;
+    right: 0;
+    width: 240px;
+    padding: 0.8rem;
+    border-radius: 12px;
+    background: rgba(19, 43, 64, 0.92);
+    border: 1px solid rgba(255,255,255,0.25);
+    color: #e6f7ff;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    text-align: left;
+    box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.endpoint-tooltip:focus .tooltip-text,
+.endpoint-tooltip:hover .tooltip-text {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
 .list {
     list-style: none;
     margin-top: 1rem;

--- a/AgendamentoMedico/src/main/resources/static/css/medico.css
+++ b/AgendamentoMedico/src/main/resources/static/css/medico.css
@@ -46,6 +46,73 @@ h2 {
     margin-bottom: 1rem;
 }
 
+.card-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+    position: relative;
+}
+
+.card-title h2 {
+    margin: 0;
+}
+
+.endpoint-tooltip {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.6rem;
+    width: 1.9rem;
+    height: 1.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+    font-weight: 700;
+    cursor: help;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.endpoint-tooltip:focus,
+.endpoint-tooltip:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.3);
+    outline: none;
+}
+
+.endpoint-tooltip .tooltip-text {
+    position: absolute;
+    top: 130%;
+    right: 0;
+    width: 240px;
+    padding: 0.8rem;
+    border-radius: 12px;
+    background: rgba(19, 43, 64, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: #e6f7ff;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    text-align: left;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.endpoint-tooltip:focus .tooltip-text,
+.endpoint-tooltip:hover .tooltip-text {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
 
 #medicosList {
     flex: 1;

--- a/AgendamentoMedico/src/main/resources/static/css/paciente.css
+++ b/AgendamentoMedico/src/main/resources/static/css/paciente.css
@@ -52,6 +52,73 @@ h2 {
     margin-bottom: 1rem;
 }
 
+.card-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+    position: relative;
+}
+
+.card-title h2 {
+    margin: 0;
+}
+
+.endpoint-tooltip {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.6rem;
+    width: 1.9rem;
+    height: 1.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.6);
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-weight: 700;
+    cursor: help;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.endpoint-tooltip:focus,
+.endpoint-tooltip:hover {
+    transform: translateY(-2px);
+    background: rgba(255,255,255,0.3);
+    outline: none;
+}
+
+.endpoint-tooltip .tooltip-text {
+    position: absolute;
+    top: 130%;
+    right: 0;
+    width: 240px;
+    padding: 0.8rem;
+    border-radius: 12px;
+    background: rgba(19, 43, 64, 0.92);
+    border: 1px solid rgba(255,255,255,0.25);
+    color: #e6f7ff;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    text-align: left;
+    box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.endpoint-tooltip:focus .tooltip-text,
+.endpoint-tooltip:hover .tooltip-text {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
 .form-group {
     margin-bottom: 1rem;
 }

--- a/AgendamentoMedico/src/main/resources/static/especialidade.html
+++ b/AgendamentoMedico/src/main/resources/static/especialidade.html
@@ -25,7 +25,16 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2 id="formTitle">Nova Especialidade</h2>
+            <div class="card-title">
+                <h2 id="formTitle">Nova Especialidade</h2>
+                <button type="button" class="endpoint-tooltip" aria-label="Informações sobre o endpoint utilizado neste formulário">
+                    ?
+                    <span class="tooltip-text" role="tooltip">
+                        <strong>Endpoint:</strong> POST /api/especialidades<br>
+                        Cria uma especialidade médica ou atualiza informações existentes.
+                    </span>
+                </button>
+            </div>
 
             <form id="especialidadeForm">
                 <div class="form-group">

--- a/AgendamentoMedico/src/main/resources/static/medico.html
+++ b/AgendamentoMedico/src/main/resources/static/medico.html
@@ -30,7 +30,16 @@
     </section>
 
     <section class="glass-card">
-        <h2 id="formTitle">Novo Médico</h2>
+        <div class="card-title">
+            <h2 id="formTitle">Novo Médico</h2>
+            <button type="button" class="endpoint-tooltip" aria-label="Informações sobre o endpoint utilizado neste formulário">
+                ?
+                <span class="tooltip-text" role="tooltip">
+                    <strong>Endpoint:</strong> POST /api/medicos<br>
+                    Envia os dados preenchidos para cadastrar ou atualizar um médico na plataforma.
+                </span>
+            </button>
+        </div>
         <form id="medicoForm">
             <div class="form-group">
                 <label for="nome">Nome do Médico</label>

--- a/AgendamentoMedico/src/main/resources/static/paciente.html
+++ b/AgendamentoMedico/src/main/resources/static/paciente.html
@@ -25,7 +25,16 @@
         </div>
 
         <div class="glass-card form-card">
-            <h2 id="formTitle">Novo Paciente</h2>
+            <div class="card-title">
+                <h2 id="formTitle">Novo Paciente</h2>
+                <button type="button" class="endpoint-tooltip" aria-label="Informações sobre o endpoint utilizado neste formulário">
+                    ?
+                    <span class="tooltip-text" role="tooltip">
+                        <strong>Endpoint:</strong> POST /api/pacientes<br>
+                        Registra um novo paciente ou atualiza os dados de um paciente existente.
+                    </span>
+                </button>
+            </div>
 
             <form id="pacienteForm">
                 <div class="form-group">


### PR DESCRIPTION
## Summary
- add endpoint tooltip buttons to the médico, paciente, especialidade e convênio formulários
- apply shared tooltip styling to each página para manter a experiência consistente

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7dae0a9b883208cd90b4605c323bb